### PR TITLE
Add support for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+sudo: required
+dist: trusty
+before_install:
+- sudo apt-get -qq update
+- sudo apt-get install -q -y texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-fonts-extra
+script:
+- make
+- mkdir build
+- cp openssl-book.pdf build
+deploy:
+  provider: pages
+  skip-cleanup: true
+  github-token: $GITHUB_TOKEN  # Set in travis-ci.org dashboard, marked secure
+  keep-history: true
+  local-dir: build
+  on:
+    branch: master

--- a/README
+++ b/README
@@ -23,6 +23,9 @@ contain content that should enable the reader to get to a level of familiarity
 with OpenSSL that they can then use the other documentation sources (such as the
 man pages) to find detailed information as required.
 
+The latest draft of the book is available at:
+https://openssl.github.io/openssl-book/openssl-book.pdf
+
 NOTE: This is a very initial draft and there is no content in the guide yet!
 
 Building the OpenSSL Guide


### PR DESCRIPTION
The script:

- Verifies that the the pdf can be generated without errors
- Publishes the latest version to Github pages

In order for this to work, Travis CI must be configured for this project.
You will also need to [generate an authentication token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) for Github so that Travis can publish the latest version of the pdf.

This page has all the [instructions](https://docs.travis-ci.com/user/deployment/pages/) but I am happy to help if they are not clear :)

The link to the pdf has also been added to the README so that people can see a preview of the book without installing Tex Live on their system.
It won't work until Travis has been configured, but in the meantime you can see a preview of the result here: https://muffo.github.io/openssl-book/openssl-book.pdf